### PR TITLE
add exec_prefix to wxsqlite3.pc

### DIFF
--- a/wxsqlite3.pc.in
+++ b/wxsqlite3.pc.in
@@ -1,6 +1,7 @@
 # Package Information for pkg-config
 
 prefix=@prefix@
+exec_prefix=@exec_prefix@
 wxver=@WX_VERSION_MAJOR@.@WX_VERSION_MINOR@
 includedir=@includedir@
 libdir=@libdir@


### PR DESCRIPTION
This fixes an error when being used by cmake's
`PKG_CHECK_MODULES( LIBWXSQLITE3 wxsqlite3 )`,
which is basically the following error:

```
$ pkg-config --libs wxsqlite3
Variable 'exec_prefix' not defined in '/usr/lib/pkgconfig/wxsqlite3.pc'
```