### PR TITLE
Fix missing CodecTerm() to free codec->m_aes

### DIFF
--- a/sqlite3/secure/src/codecext.c
+++ b/sqlite3/secure/src/codecext.c
@@ -17,6 +17,7 @@ void sqlite3CodecFree(void *pCodecArg)
   {
     CodecTerm(pCodecArg);
     sqlite3_free(pCodecArg);
+    pCodecArg = NULL;
   }
 }
 
@@ -132,8 +133,13 @@ int sqlite3CodecAttach(sqlite3* db, int nDb, const void* zKey, int nKey)
       else
       {
         CodecSetIsEncrypted(codec, 0);
-        sqlite3_free(codec);
+        sqlite3CodecFree(codec);
       }
+    }
+    else
+    {
+      CodecSetIsEncrypted(codec, 0);
+      sqlite3CodecFree(codec);
     }
   }
   else


### PR DESCRIPTION
Hi @utelle , 

We found there are memory leak during sqlite3CodecAttach()
Would you mind help to review and see whether it should be merged? 
Thanks!