### PR TITLE
Fix compile errors under Linux

### DIFF
--- a/sqlite3secure/src/chacha20poly1305.c
+++ b/sqlite3secure/src/chacha20poly1305.c
@@ -260,7 +260,6 @@ int poly1305_tagcmp(const unsigned char tag1[16], const unsigned char tag2[16])
 #include <sys/syscall.h>
 
 #ifdef __linux__
-#include <stropts.h>
 #include <linux/random.h>
 #endif
 


### PR DESCRIPTION
While [compiling 4.0.2 on CentOS](https://travis-ci.org/moneymanagerex/moneymanagerex/jobs/366589346#L709):
```
wxsqlite3/sqlite3secure/src/sqlite3secure.c:49:0:
wxsqlite3/sqlite3secure/src/chacha20poly1305.c:263:21: fatal error: stropts.h: No such file or directory
 #include <stropts.h>
                     ^
compilation terminated.
```
This header file is [not available in multiple Linux distros](https://bugzilla.redhat.com/show_bug.cgi?id=656245) and this line can be removed without negative impact.