### PR TITLE
Document legacy cipher modes

### DIFF
--- a/sqlite3secure/readme.md
+++ b/sqlite3secure/readme.md
@@ -176,7 +176,9 @@ The following table lists all parameters related to this cipher that can be set 
 
 ## <a name="legacy" /> Legacy cipher modes
 
-Since version 3.1.0, wxSQLite3 won't encrypt bytes 16 through 23 of the [database header](https://www.sqlite.org/fileformat.html#the_database_header) unless the `legacy` parameter is explicitly set. In legacy mode the database header is fully encrypted, which is a problem because it usually prevents SQLite from correctly determining the database page size. The official [SQLite Encryption Extension (SEE)](https://www.sqlite.org/see) implementation doesn't encrypt these header bytes as well.
+SQLite reads bytes 16 through 23 from the [database header](https://www.sqlite.org/fileformat.html#the_database_header) before the database file is actually opened. The main purpose of this is to detect the page size and the number of reserved bytes per page. Legacy ciphers used to encrypt these header bytes as well, but this may prevent SQLite from successfully opening the database file.
+
+The official [SQLite Encryption Extension (SEE)](https://www.sqlite.org/see) leaves these header bytes unencrypted for this reason. Since version 3.1.0, wxSQLite3 also doesn't encrypt these header bytes unless the `legacy` parameter is explicitly set.
 
 When using the ciphers **sqleet** (ChaCha20) or **SQLCipher**, this means that the databases written by wxSQLite3 won't be compatible with the original ciphers provided by [sqleet](https://github.com/resilar/sqleet) and [SQLCipher (Zetetic LLC)](http://zetetic.net) unless the `legacy` parameter is explicitly set. This is because the original implementations fully encrypt the database header by default. (Note that **sqleet** can also be compiled in non-legacy mode, and future releases of **SQLCipher** will probably provide this option as well.)
 

--- a/sqlite3secure/readme.md
+++ b/sqlite3secure/readme.md
@@ -273,7 +273,7 @@ Parameter names use the following prefixes:
 
 | Prefix | Description|
 | :--- | :--- |
-| *<no prefix>* | Get or set the *transient* parameter value. Transient values are only used **once** for the next call to `sqlite3_key()` or `sqlite3_rekey()`. Afterwards, the *permanent* default values will be used again (see below). |
+| *no prefix* | Get or set the *transient* parameter value. Transient values are only used **once** for the next call to `sqlite3_key()` or `sqlite3_rekey()`. Afterwards, the *permanent* default values will be used again (see below). |
 | `default:` | Get or set the *permanent* default parameter value. Permanent values will be used during the entire lifetime of the `db` database instance, unless explicitly overridden by a transient value. The initial values for the permanent default values are the compile-time default values. |
 | `min:` | Get the lower bound of the valid parameter value range. This is read-only. |
 | `max:` | Get the upper bound of the valid parameter value range. This is read-only. |


### PR DESCRIPTION
Documented `legacy_page_size` parameter.
Reworded "Legacy cipher modes" section.
Improved formatting.

Please review and correct any errors. Thanks :-)

I'm not sure which default page size is actually used for legacy AES-128 and AES-256, since the default `legacy_page_size` is defined as `0` in the code. I guess this means to use the SQLite default page size?