### PR TITLE
Fixes for MSVS warnings, and to allow vcpkg to know about DLL Debug and DLL Release

### DIFF
--- a/build/wxsqlite3_vc16_wxsqlite3.vcxproj
+++ b/build/wxsqlite3_vc16_wxsqlite3.vcxproj
@@ -107,24 +107,32 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Debug|Win32'" Label="Configuration">
+    <!-- ga2k - Added property VcpkgConfiguration so Configuration DLL Debug is identified as a Debug build -->
+    <VcpkgConfiguration Condition="'$(Configuration)' == 'DLL Debug'">Debug</VcpkgConfiguration>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'" Label="Configuration">
+    <!-- ga2k - Added property VcpkgConfiguration so Configuration DLL Debug is identified as a Debug build -->
+    <VcpkgConfiguration Condition="'$(Configuration)' == 'DLL Debug'">Debug</VcpkgConfiguration>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|Win32'" Label="Configuration">
+    <!-- ga2k - Added property VcpkgConfiguration so Configuration DLL Release is identified as a Release build -->
+    <VcpkgConfiguration Condition="'$(Configuration)' == 'DLL Release'">Release</VcpkgConfiguration>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'" Label="Configuration">
+    <!-- ga2k - Added property VcpkgConfiguration so Configuration DLL Release is identified as a Release build -->
+    <VcpkgConfiguration Condition="'$(Configuration)' == 'DLL Release'">Release</VcpkgConfiguration>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>


### PR DESCRIPTION
@utelle I coded up a change or two here because vcpkg didn't know how to handle the Configurations that didn't start with Debug or Release (DLL Debug and DLL Release). It was a simple one line change in each PropertyGroup.

I also added a #pragma warning(disable : 4267) to stop VS from complaining about narrowing from size_t to int. I put it at the very top of sqlite3_amalgamation.c  but move it to wherever you want it.

This is my first ever Pull Request, be gentle... :-)
